### PR TITLE
Remove usage of a.void in popups - function is already wrapped in

### DIFF
--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -1,4 +1,5 @@
 local cli = require("neogit.lib.git.cli")
+local stash = require("neogit.lib.git.stash")
 local diff_lib = require("neogit.lib.git.diff")
 local util = require("neogit.lib.util")
 local config = require("neogit.config")
@@ -212,6 +213,11 @@ end
 ---@return CommitLogEntry[]
 function M.list(options)
   local result = cli.log.oneline.max_count(36).arg_list(options or {}).call()
+  return parse_log(result.stdout)
+end
+
+function M.list_with_stashes()
+  local result = cli.log.oneline.all.max_count(36).arg_list(stash.list()).call():trim()
   return parse_log(result.stdout)
 end
 

--- a/lua/neogit/lib/git/stash.lua
+++ b/lua/neogit/lib/git/stash.lua
@@ -70,8 +70,13 @@ local function update_stashes(state)
   state.stashes.items = parse(result.stdout)
 end
 
+local function list()
+  return cli.reflog.show.format("%h").args("stash").call():trim().stdout
+end
+
 return {
   parse = parse,
+  list = list,
   stash_all = function()
     cli.stash.call()
     -- this should work, but for some reason doesn't.

--- a/lua/neogit/popups/cherry_pick.lua
+++ b/lua/neogit/popups/cherry_pick.lua
@@ -43,7 +43,7 @@ function M.create(env)
       not pick_or_revert_in_progress(status),
       "A",
       "Pick",
-      a.void(function(popup)
+      function(popup)
         local commits
         if popup.state.env.commits then
           commits = util.filter_map(popup.state.env.commits, function(item)
@@ -61,13 +61,13 @@ function M.create(env)
 
         a.util.scheduler()
         status.refresh(true, "cherry_pick_pick")
-      end)
+      end
     )
     :action_if(
       not pick_or_revert_in_progress(status),
       "a",
       "Apply",
-      a.void(function(popup)
+      function(popup)
         local commits
         if popup.state.env.commits then
           commits = util.filter_map(popup.state.env.commits, function(item)
@@ -85,7 +85,7 @@ function M.create(env)
 
         a.util.scheduler()
         status.refresh(true, "cherry_pick_apply")
-      end)
+      end
     )
     :action_if(not pick_or_revert_in_progress(status), "h", "Harvest", false)
     :action_if(not pick_or_revert_in_progress(status), "m", "Squash", false)

--- a/lua/neogit/popups/rebase.lua
+++ b/lua/neogit/popups/rebase.lua
@@ -35,11 +35,11 @@ function M.create()
       :action(
         "p",
         "master", -- use pushremote? ((If there is no pushremote, add ", setting that" suffix))
-        a.void(function(popup)
+        function(popup)
           rebase.rebase_onto("master", popup:get_arguments())
           a.util.scheduler()
           status.refresh(true, "rebase_master")
-        end)
+        end
       )
       :action(
         "u",
@@ -49,18 +49,18 @@ function M.create()
       :action(
         "e",
         "elsewhere",
-        a.void(function(popup)
+        function(popup)
           local branch = git.branch.prompt_for_branch(git.branch.get_all_branches())
           rebase.rebase_onto(branch, popup:get_arguments())
           a.util.scheduler()
           status.refresh(true, "rebase_elsewhere")
-        end)
+        end
       )
       :new_action_group("Rebase")
       :action(
         "i",
         "interactively",
-        a.void(function(popup)
+        function(popup)
           local commits = require("neogit.lib.git.log").list()
 
           local commit = CommitSelectViewBuffer.new(commits):open_async()
@@ -72,7 +72,7 @@ function M.create()
           rebase.rebase_interactive(commit.oid, unpack(popup:get_arguments()))
           a.util.scheduler()
           status.refresh(true, "rebase_interactive")
-        end)
+        end
       )
       :action("s", "a subset", false)
       :new_action_group()

--- a/lua/neogit/popups/reset.lua
+++ b/lua/neogit/popups/reset.lua
@@ -18,7 +18,7 @@ function M.create()
     :action(
       "m",
       "mixed    (HEAD and index)",
-      a.void(function()
+      function()
         local commit = CommitSelectViewBuffer.new(git.log.list()):open_async()
         if not commit then
           return
@@ -27,12 +27,12 @@ function M.create()
         git.reset.mixed(commit.oid)
         a.util.scheduler()
         status.refresh(true, "reset_mixed")
-      end)
+      end
     )
     :action(
       "s",
       "soft     (HEAD only)",
-      a.void(function()
+      function()
         local commit = CommitSelectViewBuffer.new(git.log.list()):open_async()
         if not commit then
           return
@@ -41,12 +41,12 @@ function M.create()
         git.reset.soft(commit.oid)
         a.util.scheduler()
         status.refresh(true, "reset_soft")
-      end)
+      end
     )
     :action(
       "h",
       "hard     (HEAD, index and files)",
-      a.void(function()
+      function()
         local commit = CommitSelectViewBuffer.new(git.log.list()):open_async()
         if not commit then
           return
@@ -55,12 +55,12 @@ function M.create()
         git.reset.hard(commit.oid)
         a.util.scheduler()
         status.refresh(true, "reset_hard")
-      end)
+      end
     )
     :action(
       "k",
       "keep     (HEAD and index, keeping uncommitted)",
-      a.void(function()
+      function()
         local commit = CommitSelectViewBuffer.new(git.log.list()):open_async()
         if not commit then
           return
@@ -69,7 +69,7 @@ function M.create()
         git.reset.keep(commit.oid)
         a.util.scheduler()
         status.refresh(true, "reset_keep")
-      end)
+      end
     )
     :action("i", "index    (only)", false) -- https://github.com/magit/magit/blob/main/lisp/magit-reset.el#L78
     :action("w", "worktree (only)", false) -- https://github.com/magit/magit/blob/main/lisp/magit-reset.el#L87
@@ -77,8 +77,8 @@ function M.create()
     :action(
       "f",
       "a file",
-      a.void(function()
-        local commit = CommitSelectViewBuffer.new(git.log.list()):open_async()
+      function()
+        local commit = CommitSelectViewBuffer.new(git.log.list_with_stashes()):open_async()
         if not commit then
           return
         end
@@ -99,7 +99,7 @@ function M.create()
           git.reset.file(commit.oid, filepath)
           status.dispatch_refresh(true)
         end):open()
-      end)
+      end
     )
     :build()
 


### PR DESCRIPTION
All actions are already `a.void()` wrapped, no need to double that.