### PR TITLE
Expand "kind" configuration

### DIFF
--- a/lua/neogit/buffers/commit_editor/init.lua
+++ b/lua/neogit/buffers/commit_editor/init.lua
@@ -36,7 +36,7 @@ function M:open()
     filetype = "NeogitCommitMessage",
     load = true,
     buftype = "",
-    kind = config.values.commit_popup.kind,
+    kind = config.values.commit_editor.kind,
     modifiable = true,
     readonly = false,
     autocmds = {

--- a/lua/neogit/buffers/commit_select_view/init.lua
+++ b/lua/neogit/buffers/commit_select_view/init.lua
@@ -1,6 +1,7 @@
 local a = require("plenary.async")
 local Buffer = require("neogit.lib.buffer")
 local ui = require("neogit.buffers.commit_select_view.ui")
+local config = require("neogit.config")
 
 ---@class CommitSelectViewBuffer
 ---@field commits CommitLogEntry[]
@@ -40,7 +41,7 @@ function M:open(action)
   self.buffer = Buffer.create {
     name = "NeogitCommitSelectView",
     filetype = "NeogitCommitSelectView",
-    kind = "tab",
+    kind = config.values.commit_select_view.kind,
     mappings = {
       n = {
         ["<tab>"] = function()

--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -3,6 +3,7 @@ local cli = require("neogit.lib.git.cli")
 local parser = require("neogit.buffers.commit_view.parsing")
 local ui = require("neogit.buffers.commit_view.ui")
 local log = require("neogit.lib.git.log")
+local config = require("neogit.config")
 
 local CherryPickPopup = require("neogit.popups.cherry_pick")
 
@@ -71,7 +72,7 @@ function M:open()
   self.buffer = Buffer.create {
     name = "NeogitCommitView",
     filetype = "NeogitCommitView",
-    kind = "vsplit",
+    kind = config.values.commit_view.kind,
     context_highlight = true,
     autocmds = {
       ["BufUnload"] = function()

--- a/lua/neogit/buffers/log_view/init.lua
+++ b/lua/neogit/buffers/log_view/init.lua
@@ -38,7 +38,7 @@ function M:open()
   self.buffer = Buffer.create {
     name = "NeogitLogView",
     filetype = "NeogitLogView",
-    kind = "tab",
+    kind = config.values.log_view.kind,
     context_highlight = false,
     mappings = {
       v = {

--- a/lua/neogit/buffers/merge_editor.lua
+++ b/lua/neogit/buffers/merge_editor.lua
@@ -1,4 +1,5 @@
 local Buffer = require("neogit.lib.buffer")
+local config = require("neogit.config")
 
 local M = {}
 
@@ -20,7 +21,7 @@ function M:open()
     load = true,
     filetype = "NeogitMergeMessage",
     buftype = "",
-    kind = "split",
+    kind = config.values.merge_editor.kind,
     modifiable = true,
     readonly = false,
     autocmds = {

--- a/lua/neogit/buffers/rebase_editor/init.lua
+++ b/lua/neogit/buffers/rebase_editor/init.lua
@@ -21,7 +21,7 @@ function M:open()
     load = true,
     filetype = "NeogitRebaseTodo",
     buftype = "",
-    kind = config.values.commit_popup.kind,
+    kind = config.values.rebase_editor.kind,
     modifiable = true,
     readonly = false,
     autocmds = {

--- a/lua/neogit/buffers/reflog_view/init.lua
+++ b/lua/neogit/buffers/reflog_view/init.lua
@@ -34,7 +34,7 @@ function M:open()
   self.buffer = Buffer.create {
     name = "NeogitReflogView",
     filetype = "NeogitReflogView",
-    kind = "tab",
+    kind = config.values.reflog_view.kind,
     context_highlight = true,
     mappings = {
       v = {

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -22,7 +22,28 @@ M.values = {
     recent_commit_count = 10,
   },
   commit_popup = {
-    kind = "split",
+    kind = "split"
+  },
+  commit_editor = {
+    kind = "split"
+  },
+  commit_select_view = {
+    kind = "tab"
+  },
+  commit_view = {
+    kind = "vsplit"
+  },
+  log_view = {
+    kind = "tab"
+  },
+  rebase_editor = {
+    kind = "split"
+  },
+  reflog_view = {
+    kind = "tab"
+  },
+  merge_editor = {
+    kind = "split"
   },
   preview_buffer = {
     kind = "split",


### PR DESCRIPTION
Expand "kind" configuration for more flexibility, this allows preferences such as using split over vsplit for commit view and more.

#### Example:

![image](https://github.com/CKolkey/neogit/assets/91024200/01b6c21d-78ef-4199-9a8c-49d1a2c622ab)
